### PR TITLE
[FIX] Support Including Model Name in Request Body for Single-Deployment Endpoints

### DIFF
--- a/pipelines/azure/azure_ai_foundry.py
+++ b/pipelines/azure/azure_ai_foundry.py
@@ -90,31 +90,19 @@ class Pipe:
 
         # Filter allowed parameters
         allowed_params = {
+            "model",
             "messages",
-            "temperature",
-            "role",
-            "content",
-            "contentPart",
-            "contentPartImage",
-            "enhancements",
-            "dataSources",
-            "n",
-            "stream",
-            "stop",
+            "frequency_penalty",
             "max_tokens",
             "presence_penalty",
-            "frequency_penalty",
-            "logit_bias",
-            "user",
-            "function_call",
-            "funcions",
-            "tools",
-            "tool_choice",
-            "top_p",
-            "log_probs",
-            "top_logprobs",
             "response_format",
             "seed",
+            "stop",
+            "stream",
+            "temperature",
+            "tool_choice",
+            "tools",
+            "top_p",
         }
         filtered_body = {k: v for k, v in body.items() if k in allowed_params}
 
@@ -129,7 +117,7 @@ class Pipe:
                 json=filtered_body,
                 headers=headers,
                 stream=do_stream,
-                timeout=60 if do_stream else 30,  # Longer timeout for streaming
+                timeout=600 if do_stream else 300,  # Longer timeout for streaming
             )
             response.raise_for_status()
 

--- a/pipelines/azure/azure_ai_foundry.py
+++ b/pipelines/azure/azure_ai_foundry.py
@@ -43,6 +43,12 @@ class Pipe:
             default=os.getenv("AZURE_AI_MODEL", ""),
             description="Optional model name for Azure AI"
         )
+      
+        # Switch for sending model name in request body
+        AZURE_AI_MODEL_IN_BODY: bool = Field(
+            default=False,
+            description="If True, include the model name in the request body instead of as a header.",
+        )
 
     def __init__(self):
         self.name = "Azure AI"
@@ -66,7 +72,9 @@ class Pipe:
             "api-key": self.valves.AZURE_AI_API_KEY,
             "Content-Type": "application/json",
         }
-        if self.valves.AZURE_AI_MODEL:
+        # If the valve indicates that the model name should be in the body,
+        # add it to the filtered body.
+        if self.valves.AZURE_AI_MODEL and self.valves.AZURE_AI_MODEL_IN_BODY:
             headers["x-ms-model-mesh-model-name"] = self.valves.AZURE_AI_MODEL
         return headers
 
@@ -105,6 +113,11 @@ class Pipe:
             "top_p",
         }
         filtered_body = {k: v for k, v in body.items() if k in allowed_params}
+      
+        # If the valve indicates that the model name should be in the body,
+        # add it to the filtered body.
+        if self.valves.AZURE_AI_MODEL and self.valves.AZURE_AI_MODEL_IN_BODY:
+            filtered_body["model"] = self.valves.AZURE_AI_MODEL
 
         response = None
         try:


### PR DESCRIPTION
User may have issue using Azure DeepSeek-R1 (default deployment) on Open WebUI with this function prior to this fix. 

This pull request addresses an issue where the model name is not correctly appended to the request payload when using endpoints that do not support multiple deployments. In the current implementation, the model name is always added as a header (x-ms-model-mesh-model-name), which works fine for endpoints that support multiple deployments. However, for endpoints that require the model name to be part of the request body, this behavior may lead to unexpected failures (e.g., conversation branching and multi-round chats causing the interface to freeze).

Changes Made:
- New Configuration Valve:
  Added a new environment/configuration variable AZURE_AI_MODEL_IN_BODY to indicate whether the model name should be included in the request body.
- Conditional Header Assignment:
  Updated the get_headers() method to only add the model name as a header if AZURE_AI_MODEL_IN_BODY is set to False.
- Appending Model to Request Body:
  Modified the pipe() method so that if AZURE_AI_MODEL_IN_BODY is True, the model name is added to the filtered request body under the "model" key.
- Allowed Parameters Update:
  Ensured that the allowed parameters list complies with Azure AI chat-completions specification.
 - Longer timeout:
    hardcoded timeout changed to be the same as pipelines/azure/azure_ai_foundry_deepseek.py.

Ref:
https://learn.microsoft.com/en-us/azure/ai-foundry/model-inference/reference/reference-model-inference-chat-completions