### PR TITLE
Add all azure models as pipes()

### DIFF
--- a/pipelines/azure/azure_ai_foundry.py
+++ b/pipelines/azure/azure_ai_foundry.py
@@ -4,7 +4,7 @@ author: owndev
 author_url: https://github.com/owndev
 project_url: https://github.com/owndev/Open-WebUI-Functions
 funding_url: https://github.com/owndev/Open-WebUI-Functions
-version: 1.0.2
+version: 1.0.3
 license: MIT
 description: A Python-based pipeline for interacting with Azure AI services, enabling seamless communication with various AI models via configurable headers and robust error handling. This includes support for Azure OpenAI models as well as other Azure AI models by dynamically managing headers and request configurations.
 features:
@@ -15,10 +15,11 @@ features:
   - Compatible with Azure OpenAI and other Azure AI models.
 """
 
-from typing import Union, Generator, Iterator
+from typing import List, Union, Generator, Iterator
 from pydantic import BaseModel, Field
 import requests
 import os
+
 
 class Pipe:
     # Environment variables for API key, endpoint, and optional model
@@ -26,24 +27,24 @@ class Pipe:
         # API key for Azure AI
         AZURE_AI_API_KEY: str = Field(
             default=os.getenv("AZURE_AI_API_KEY", "API_KEY"),
-            description="API key for Azure AI"
+            description="API key for Azure AI",
         )
 
         # Endpoint for Azure AI (e.g. "https://<your-endpoint>/chat/completions?api-version=2024-05-01-preview" or "https://<your-endpoint>/openai/deployments/gpt-4o/chat/completions?api-version=2024-08-01-preview")
         AZURE_AI_ENDPOINT: str = Field(
             default=os.getenv(
-            "AZURE_AI_ENDPOINT",
-            "https://<your-endpoint>/chat/completions?api-version=2024-05-01-preview"
+                "AZURE_AI_ENDPOINT",
+                "https://<your-endpoint>/chat/completions?api-version=2024-05-01-preview",
             ),
-            description="Endpoint for Azure AI"
+            description="Endpoint for Azure AI",
         )
 
         # Optional model name, only necessary if not Azure OpenAI or if model name not in URL (e.g. "https://<your-endpoint>/openai/deployments/<model-name>/chat/completions")
         AZURE_AI_MODEL: str = Field(
             default=os.getenv("AZURE_AI_MODEL", ""),
-            description="Optional model name for Azure AI"
+            description="Optional model name for Azure AI",
         )
-      
+
         # Switch for sending model name in request body
         AZURE_AI_MODEL_IN_BODY: bool = Field(
             default=False,
@@ -85,6 +86,70 @@ class Pipe:
         if "messages" not in body or not isinstance(body["messages"], list):
             raise ValueError("The 'messages' field is required and must be a list.")
 
+    def get_azure_models(self):
+        return [
+            {"id": "AI21-Jamba-1.5-Large", "name": "AI21 Jamba 1.5 Large"},
+            {"id": "AI21-Jamba-1.5-Mini", "name": "AI21 Jamba 1.5 Mini"},
+            {"id": "Codestral-2501", "name": "Codestral 25.01"},
+            {"id": "Cohere-command-r", "name": "Cohere Command R"},
+            {"id": "Cohere-command-r-08-2024", "name": "Cohere Command R 08-2024"},
+            {"id": "Cohere-command-r-plus", "name": "Cohere Command R+"},
+            {
+                "id": "Cohere-command-r-plus-08-2024",
+                "name": "Cohere Command R+ 08-2024",
+            },
+            {"id": "DeepSeek-R1", "name": "DeepSeek-R1"},
+            {"id": "jais-30b-chat", "name": "JAIS 30b Chat"},
+            {
+                "id": "Llama-3.2-11B-Vision-Instruct",
+                "name": "Llama-3.2-11B-Vision-Instruct",
+            },
+            {
+                "id": "Llama-3.2-90B-Vision-Instruct",
+                "name": "Llama-3.2-90B-Vision-Instruct",
+            },
+            {"id": "Llama-3.3-70B-Instruct", "name": "Llama-3.3-70B-Instruct"},
+            {"id": "Meta-Llama-3-70B-Instruct", "name": "Meta-Llama-3-70B-Instruct"},
+            {"id": "Meta-Llama-3-8B-Instruct", "name": "Meta-Llama-3-8B-Instruct"},
+            {
+                "id": "Meta-Llama-3.1-405B-Instruct",
+                "name": "Meta-Llama-3.1-405B-Instruct",
+            },
+            {
+                "id": "Meta-Llama-3.1-70B-Instruct",
+                "name": "Meta-Llama-3.1-70B-Instruct",
+            },
+            {"id": "Meta-Llama-3.1-8B-Instruct", "name": "Meta-Llama-3.1-8B-Instruct"},
+            {"id": "Ministral-3B", "name": "Ministral 3B"},
+            {"id": "Mistral-large", "name": "Mistral Large"},
+            {"id": "Mistral-large-2407", "name": "Mistral Large (2407)"},
+            {"id": "Mistral-Large-2411", "name": "Mistral Large 24.11"},
+            {"id": "Mistral-Nemo", "name": "Mistral Nemo"},
+            {"id": "Mistral-small", "name": "Mistral Small"},
+            {"id": "gpt-4o", "name": "OpenAI GPT-4o"},
+            {"id": "gpt-4o-mini", "name": "OpenAI GPT-4o mini"},
+            {"id": "o1", "name": "OpenAI o1"},
+            {"id": "o1-mini", "name": "OpenAI o1-mini"},
+            {"id": "o1-preview", "name": "OpenAI o1-preview"},
+            {"id": "o3-mini", "name": "OpenAI o3-mini"},
+            {
+                "id": "Phi-3-medium-128k-instruct",
+                "name": "Phi-3-medium instruct (128k)",
+            },
+            {"id": "Phi-3-medium-4k-instruct", "name": "Phi-3-medium instruct (4k)"},
+            {"id": "Phi-3-mini-128k-instruct", "name": "Phi-3-mini instruct (128k)"},
+            {"id": "Phi-3-mini-4k-instruct", "name": "Phi-3-mini instruct (4k)"},
+            {"id": "Phi-3-small-128k-instruct", "name": "Phi-3-small instruct (128k)"},
+            {"id": "Phi-3-small-8k-instruct", "name": "Phi-3-small instruct (8k)"},
+            {"id": "Phi-3.5-mini-instruct", "name": "Phi-3.5-mini instruct (128k)"},
+            {"id": "Phi-3.5-MoE-instruct", "name": "Phi-3.5-MoE instruct (128k)"},
+            {"id": "Phi-3.5-vision-instruct", "name": "Phi-3.5-vision instruct (128k)"},
+            {"id": "Phi-4", "name": "Phi-4"},
+        ]
+
+    def pipes(self) -> List[dict]:
+        return self.get_azure_models()
+
     def pipe(self, body: dict) -> Union[str, Generator, Iterator]:
         """
         Main method for sending requests to the Azure AI endpoint.
@@ -113,11 +178,13 @@ class Pipe:
             "top_p",
         }
         filtered_body = {k: v for k, v in body.items() if k in allowed_params}
-      
+
         # If the valve indicates that the model name should be in the body,
         # add it to the filtered body.
         if self.valves.AZURE_AI_MODEL and self.valves.AZURE_AI_MODEL_IN_BODY:
             filtered_body["model"] = self.valves.AZURE_AI_MODEL
+        elif filtered_body["model"]:
+            filtered_body["model"] = filtered_body["model"].split(".")[-1]
 
         response = None
         try:


### PR DESCRIPTION
This won't work yet with OpenAI, which has a slightly different endpoint path - but it's a great start to make all models available in OpenWeb UI.

As there is no good way to get a list of deployed models, the easiest is to just use the list from GitHub co-pilot.

List has been retrieved via:

```
gh models list | awk -F'\t' '{ printf("            {|id|: |%s|,|name|: |%s|},\n", $2, $1); }' | tr '|' "'"
```