### PR TITLE
Fixup Function

### DIFF
--- a/pipelines/azure/azure_ai_foundry_deepseek.py
+++ b/pipelines/azure/azure_ai_foundry_deepseek.py
@@ -62,7 +62,7 @@ class Pipe:
             description="Endpoint for DeepSeek-R1 in Azure AI",
         )
 
-        # Model name, necessary by Azure OpenAI 
+        # Model name, necessary by Azure OpenAI
         # "Use parameter model = "DeepSeek-R1" to use this deployment in your request to use this deployment"
         # https://learn.microsoft.com/en-us/azure/ai-foundry/model-inference/concepts/endpoints?tabs=python#routing
         AZURE_AI_MODEL: str = Field(


### PR DESCRIPTION
Needs the model name to be passed, also it's "api-key" and not "bearer auth" for deepseek deployed models. At least in my case - we could add both types. 