### PR TITLE
Add google search grounding

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ Pipelines are processing functions that extend Open WebUI with **custom AI model
 - Supports encryption of sensitive information like API keys.
 - Supports both streaming and non-streaming responses.
 - Provides configurable error handling and timeouts.
+- Grounding with Google search with [google_search_tool.py filter](./filters/google_search_tool.py)
 
 🔗 [Google Gemini Pipeline in Open WebUI](https://own.dev/openwebui-com-f-owndev-google-gemini)
 

--- a/docs/google-gemini-integration.md
+++ b/docs/google-gemini-integration.md
@@ -98,20 +98,6 @@ GOOGLE_CLOUD_LOCATION="your-gcp-location"
 
 Grounding with Google search is enabled/disabled with the `google_search_tool` feature, which can be switched on/off in a Filter.
 
-For instance, the following Filter will replace Open Web UI default web search function with google search grounding
-
-```python
-class Filter:
-    def inlet(self, body: dict) -> dict:
-        features = body.get("features", {})
-
-        metadata = body.setdefault("metadata", {})
-        metadata_features = metadata.setdefault("features", {})
-
-        if features.pop("web_search"):
-            metadata_features["google_search_tool"] = True
-        
-        return body
-```
+For instance, the following [Filter (google_search_tool.py)](../filters/google_search_tool.py) will replace Open Web UI default web search function with google search grounding.
 
 When enabled, sources and google queries used by Gemini will be displayed with the response.

--- a/docs/google-gemini-integration.md
+++ b/docs/google-gemini-integration.md
@@ -25,13 +25,13 @@ This integration enables **Open WebUI** to interact with **Google Gemini** model
 - **Multimodal Input Support**  
   Accepts both text and image data for more expressive interactions.
 
-- **Flexible Error Handling**
+- **Flexible Error Handling**  
   Retries failed requests and logs errors for transparency.
 
-- **Integration with Google Generative AI or Vertex AI API**
+- **Integration with Google Generative AI or Vertex AI API**  
   Connect using either the Google Generative AI API or Google Cloud Vertex AI for content generation.
 
-- **Secure API Key Storage**
+- **Secure API Key Storage**  
   API keys (for the Google Generative AI API method) are encrypted and never exposed in plaintext.
 
 - **Safety Configuration**  
@@ -40,8 +40,8 @@ This integration enables **Open WebUI** to interact with **Google Gemini** model
 - **Customizable Generation Settings**  
   Use environment variables to configure token limits, temperature, etc.
 
-- **Grounding with Google search**
-  Improve the accuracy and recency of Gemini responses with Google search grounding   
+- **Grounding with Google search**  
+  Improve the accuracy and recency of Gemini responses with Google search grounding.
 
 ## Environment Variables
 

--- a/docs/google-gemini-integration.md
+++ b/docs/google-gemini-integration.md
@@ -40,6 +40,9 @@ This integration enables **Open WebUI** to interact with **Google Gemini** model
 - **Customizable Generation Settings**  
   Use environment variables to configure token limits, temperature, etc.
 
+- **Grounding with Google search**
+  Improve the accuracy and recency of Gemini responses with Google search grounding   
+
 ## Environment Variables
 
 Set the following environment variables to configure the Google Gemini integration.
@@ -90,3 +93,25 @@ GOOGLE_CLOUD_PROJECT="your-gcp-project-id"
 # Defaults to "global" if not set.
 GOOGLE_CLOUD_LOCATION="your-gcp-location"
 ```
+
+## Grounding with Google search
+
+Grounding with Google search is enabled/disabled with the `google_search_tool` feature, which can be switched on/off in a Filter.
+
+For instance, the following Filter will replace Open Web UI default web search function with google search grounding
+
+```python
+class Filter:
+    def inlet(self, body: dict) -> dict:
+        features = body.get("features", {})
+
+        metadata = body.setdefault("metadata", {})
+        metadata_features = metadata.setdefault("features", {})
+
+        if features.pop("web_search"):
+            metadata_features["google_search_tool"] = True
+        
+        return body
+```
+
+When enabled, sources and google queries used by Gemini will be displayed with the response.

--- a/filters/google_search_tool.py
+++ b/filters/google_search_tool.py
@@ -1,0 +1,33 @@
+"""
+title: Google Search Tool Filter for https://github.com/owndev/Open-WebUI-Functions/blob/master/pipelines/google/google_gemini.py
+author: owndev, olivier-lacroix
+author_url: https://github.com/owndev/
+project_url: https://github.com/owndev/Open-WebUI-Functions
+funding_url: https://github.com/sponsors/owndev
+version: 1.0.0
+license: Apache License 2.0
+requirements:
+  - https://github.com/owndev/Open-WebUI-Functions/blob/master/pipelines/google/google_gemini.py
+description: Replacing web_search tool with google search grounding
+"""
+
+import logging
+from open_webui.env import SRC_LOG_LEVELS
+
+
+class Filter:
+    def __init__(self):
+        self.log = logging.getLogger("google_ai.pipe")
+        self.log.setLevel(SRC_LOG_LEVELS.get("OPENAI", logging.INFO))
+
+    def inlet(self, body: dict) -> dict:
+        features = body.get("features", {})
+
+        # Ensure metadata structure exists and add new feature
+        metadata = body.setdefault("metadata", {})
+        metadata_features = metadata.setdefault("features", {})
+
+        if features.pop("web_search"):
+            self.log.debug("Replacing web_search tool with google search grounding")
+            metadata_features["google_search_tool"] = True
+        return body

--- a/pipelines/google/google_gemini.py
+++ b/pipelines/google/google_gemini.py
@@ -30,7 +30,7 @@ import logging
 from google import genai
 from google.genai import types
 from google.genai.errors import ClientError, ServerError, APIError
-from typing import List, Union, Optional, Dict, Any, Tuple, AsyncIterator
+from typing import List, Union, Optional, Dict, Any, Tuple, AsyncIterator, Callable
 from pydantic_core import core_schema
 from pydantic import BaseModel, Field, GetCoreSchemaHandler
 from cryptography.fernet import Fernet, InvalidToken
@@ -443,7 +443,10 @@ class Pipe:
         return parts
 
     def _configure_generation(
-        self, body: Dict[str, Any], system_instruction: Optional[str] = None
+        self,
+        body: Dict[str, Any],
+        system_instruction: Optional[str],
+        features: Dict[str, Any],
     ) -> types.GenerateContentConfig:
         """
         Configure generation parameters and safety settings.
@@ -481,12 +484,46 @@ class Pipe:
             ]
             gen_config_params |= ({"safety_settings": safety_settings},)
 
+        if features.get("google_search_tool", False):
+            self.log.debug("Enabling Google search grounding")
+            gen_config_params.setdefault("tools", []).append(
+                types.Tool(google_search=types.GoogleSearch())
+            )
+
         # Filter out None values for generation config
         filtered_params = {k: v for k, v in gen_config_params.items() if v is not None}
         return types.GenerateContentConfig(**filtered_params)
 
+    @staticmethod
+    def _format_grounding_chunks_as_sources(
+        grounding_chunks: list[types.GroundingChunk],
+    ):
+        formatted_sources = []
+        for chunk in grounding_chunks:
+            context = chunk.web or chunk.retrieved_context
+            if not context:
+                continue
+
+            uri = context.uri
+            title = context.title or "Source"
+
+            formatted_sources.append(
+                {
+                    "source": {
+                        "name": title,
+                        "type": "web_search_results",
+                        "url": uri,
+                    },
+                    "document": ["Click the link to view the content."],
+                    "metadata": [{"source": title}],
+                }
+            )
+        return formatted_sources
+
     async def _handle_streaming_response(
-        self, response_iterator: Any
+        self,
+        response_iterator: Any,
+        __event_emitter__: Callable,
     ) -> AsyncIterator[str]:
         """
         Handle streaming response from Gemini API.
@@ -497,6 +534,8 @@ class Pipe:
         Returns:
             Generator yielding text chunks
         """
+        web_search_queries = []
+        grounding_chunks = []
         try:
             async for chunk in response_iterator:
                 # Check for safety feedback or empty chunks
@@ -511,8 +550,39 @@ class Pipe:
                         yield "[Blocked by safety settings]"
                     return  # Stop generation
 
+                grounding_metadata = chunk.candidates[0].grounding_metadata
+                if grounding_metadata and grounding_metadata.grounding_chunks:
+                    grounding_chunks.extend(grounding_metadata.grounding_chunks)
+                if grounding_metadata and grounding_metadata.web_search_queries:
+                    web_search_queries.extend(grounding_metadata.web_search_queries)
+
                 if chunk.text:
                     yield chunk.text
+
+            # After processing all chunks, handle grounding data
+            # Add sources to the response
+            if grounding_chunks and __event_emitter__:
+                sources = self._format_grounding_chunks_as_sources(grounding_chunks)
+                await __event_emitter__(
+                    {"type": "chat:completion", "data": {"sources": sources}}
+                )
+
+            # Add status specifying google queries used for grounding
+            if web_search_queries and __event_emitter__:
+                await __event_emitter__(
+                    {
+                        "type": "status",
+                        "data": {
+                            "action": "web_search",
+                            "description": "This response was grounded with Google Search",
+                            "urls": [
+                                f"https://www.google.com/search?q={query}"
+                                for query in web_search_queries
+                            ],
+                        },
+                    }
+                )
+
         except Exception as e:
             self.log.exception(f"Error during streaming: {e}")
             yield f"Error during streaming: {e}"
@@ -597,7 +667,12 @@ class Pipe:
         assert last_exception is not None
         raise last_exception
 
-    async def pipe(self, body: Dict[str, Any]) -> Union[str, AsyncIterator[str]]:
+    async def pipe(
+        self,
+        body: Dict[str, Any],
+        __metadata__: dict[str, Any],
+        __event_emitter__: Callable,
+    ) -> Union[str, AsyncIterator[str]]:
         """
         Main method for sending requests to the Google Gemini endpoint.
 
@@ -630,7 +705,10 @@ class Pipe:
                 return "Error: No valid message content found"
 
             # Configure generation parameters and safety settings
-            generation_config = self._configure_generation(body, system_instruction)
+            features = __metadata__.get("features", {})
+            generation_config = self._configure_generation(
+                body, system_instruction, features
+            )
 
             # Make the API call
             client = self._get_client()
@@ -648,7 +726,9 @@ class Pipe:
                         get_streaming_response
                     )
                     self.log.debug(f"Request {request_id}: Got streaming response")
-                    return self._handle_streaming_response(response_iterator)
+                    return self._handle_streaming_response(
+                        response_iterator, __event_emitter__
+                    )
 
                 except Exception as e:
                     self.log.exception(f"Error in streaming request {request_id}: {e}")

--- a/pipelines/google/google_gemini.py
+++ b/pipelines/google/google_gemini.py
@@ -1,10 +1,10 @@
 """
 title: Google Gemini Pipeline
-author: owndev
+author: owndev, olivier-lacroix
 author_url: https://github.com/owndev/
 project_url: https://github.com/owndev/Open-WebUI-Functions
 funding_url: https://github.com/sponsors/owndev
-version: 1.1.1
+version: 1.2.0
 license: Apache License 2.0
 description: A manifold pipeline for interacting with Google Gemini models, including dynamic model specification, streaming responses, and flexible error handling.
 features:

--- a/pipelines/google/google_gemini.py
+++ b/pipelines/google/google_gemini.py
@@ -18,6 +18,7 @@ features:
   - Support for various generation parameters (temperature, max tokens, etc.)
   - Customizable safety settings based on environment variables
   - Encrypted storage of sensitive API keys
+  - Grounding with Google search
 """
 
 import os

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,2 +1,2 @@
-line-length = 120
+line-length = 88
 indent-width = 4


### PR DESCRIPTION
This PR adds google search grounding if a custom feature `google_search_tool` is enabled.

Such a feature can be enabled with a simple filter, which will replace openwebui web search with grounding:

```python
class Filter:
    def __init__(self):
        self.log = logging.getLogger("google_ai.pipe")
        self.log.setLevel(SRC_LOG_LEVELS.get("OPENAI", logging.INFO))

    def inlet(self, body: dict) -> dict:
        features = body.get("features", {})

        # Ensure metadata structure exists and add new feature
        metadata = body.setdefault("metadata", {})
        metadata_features = metadata.setdefault("features", {})

        if features.pop("web_search"):
            self.log.debug("Replacing web_search tool with google search grounding")
            metadata_features["google_search_tool"] = True
        return body
```