### PR TITLE
Hardcode frozen_kwargs to handle the case where bound_callable is already 'wrapped'

### DIFF
--- a/pipelines/google/google_gemini.py
+++ b/pipelines/google/google_gemini.py
@@ -4,7 +4,7 @@ author: owndev, olivier-lacroix
 author_url: https://github.com/owndev/
 project_url: https://github.com/owndev/Open-WebUI-Functions
 funding_url: https://github.com/sponsors/owndev
-version: 1.3.0
+version: 1.3.1
 license: Apache License 2.0
 description: A manifold pipeline for interacting with Google Gemini models, including dynamic model specification, streaming responses, and flexible error handling.
 features:

--- a/pipelines/google/google_gemini.py
+++ b/pipelines/google/google_gemini.py
@@ -463,7 +463,14 @@ class Pipe:
 
         # Remove 'frozen' keyword arguments (extra_params) from the signature
         original_sig = inspect.signature(bound_callable)
-        frozen_kwargs = bound_callable.keywords
+        frozen_kwargs = {
+            "__event_emitter__",
+            "__event_call__",
+            "__user__",
+            "__metadata__",
+            "__request__",
+            "__model__",
+        }
         new_parameters = []
 
         for name, parameter in original_sig.parameters.items():
@@ -536,9 +543,7 @@ class Pipe:
                 types.Tool(google_search=types.GoogleSearch())
             )
 
-        if __metadata__.get("function_calling") == "native":
-            if __tools__ is None:
-                __tools__ = {}
+        if __tools__ is not None and __metadata__.get("function_calling") == "native":
             for name, tool_def in __tools__.items():
                 tool = self._create_tool(tool_def)
                 self.log.debug(


### PR DESCRIPTION
Just realised `bound_callable.keywords` does not work when the tool is not a coroutine (as openwebui encloses the functools.partial in a coroutine in that case).

I propose to hardcode the extra_params directly, making it more explicit, and avoids using some inspect wizardry to look in the enclosing wrapper.

Apologies for the double PR :/