### PR TITLE
Fix TypeError in generation config: incorrect tuple used in dict merge

### DIFF
--- a/pipelines/google/google_gemini.py
+++ b/pipelines/google/google_gemini.py
@@ -534,7 +534,7 @@ class Pipe:
                     category="HARM_CATEGORY_DANGEROUS_CONTENT", threshold="BLOCK_NONE"
                 ),
             ]
-            gen_config_params |= ({"safety_settings": safety_settings},)
+            gen_config_params |= {"safety_settings": safety_settings}
 
         features = __metadata__.get("features", {})
         if features.get("google_search_tool", False):

--- a/pipelines/google/google_gemini.py
+++ b/pipelines/google/google_gemini.py
@@ -4,7 +4,7 @@ author: owndev, olivier-lacroix
 author_url: https://github.com/owndev/
 project_url: https://github.com/owndev/Open-WebUI-Functions
 funding_url: https://github.com/sponsors/owndev
-version: 1.3.1
+version: 1.3.2
 license: Apache License 2.0
 description: A manifold pipeline for interacting with Google Gemini models, including dynamic model specification, streaming responses, and flexible error handling.
 features:


### PR DESCRIPTION
### Summary

Fixes a `TypeError` that occurs when the `safety_settings` option is enabled in the generation config.

### Details

- When enabling the `safety_settings` option (i.e., `USE_PERMISSIVE_SAFETY=True`), the code attempted to merge a tuple instead of a dictionary into `gen_config_params`:
  ```python
  gen_config_params |= ({"safety_settings": safety_settings},)
  ```
  This resulted in the following error:
  ```
  Configuration error: dictionary update sequence element #0 has length 1; 2 is required
  ```
- The PR replaces the incorrect line with the proper dictionary merge:
  ```python
  gen_config_params |= {"safety_settings": safety_settings}
  ```
- This ensures that the `safety_settings` option can be enabled without causing a configuration error.

### Motivation

Merging a tuple instead of a dictionary into `gen_config_params` causes a TypeError in Python. This PR corrects the merge operation so enabling `safety_settings` works as intended.