### PR TITLE
Fix merge issue and exclude private methods

### DIFF
--- a/pipelines/google/google_gemini.py
+++ b/pipelines/google/google_gemini.py
@@ -4,7 +4,7 @@ author: owndev, olivier-lacroix
 author_url: https://github.com/owndev/
 project_url: https://github.com/owndev/Open-WebUI-Functions
 funding_url: https://github.com/sponsors/owndev
-version: 1.6.7
+version: 1.6.8
 required_open_webui_version: 0.6.26
 license: Apache License 2.0
 description: Highly optimized Google Gemini pipeline with advanced image generation capabilities, intelligent compression, and streamlined processing workflows.


### PR DESCRIPTION
@owndev this PR

- fixes some merge issues following my two recent PRs
- excludes private methods from being considered as tools. I am surprised OWUI does not do this already, I may open an issue / PR there