### PR TITLE
Fix streaming prompt-feedback handling

### DIFF
--- a/pipelines/google/google_gemini.py
+++ b/pipelines/google/google_gemini.py
@@ -4,7 +4,7 @@ author: owndev, olivier-lacroix
 author_url: https://github.com/owndev/
 project_url: https://github.com/owndev/Open-WebUI-Functions
 funding_url: https://github.com/sponsors/owndev
-version: 1.8.1
+version: 1.8.2
 required_open_webui_version: 0.6.26
 license: Apache License 2.0
 description: Highly optimized Google Gemini pipeline with advanced image generation capabilities, intelligent compression, and streamlined processing workflows.


### PR DESCRIPTION
Hi, I got an exception when receiving a safety block in streaming mode:

> Error during streaming: 'async_generator' object has no attribute 'prompt_feedback'

The commit fixes it.