### PR TITLE
fix: fix the incorrect file retrieval method to obtain files from S3

### DIFF
--- a/pipelines/google/google_gemini.py
+++ b/pipelines/google/google_gemini.py
@@ -4,7 +4,7 @@ author: owndev, olivier-lacroix
 author_url: https://github.com/owndev/
 project_url: https://github.com/owndev/Open-WebUI-Functions
 funding_url: https://github.com/sponsors/owndev
-version: 1.9.1
+version: 1.9.2
 required_open_webui_version: 0.6.26
 license: Apache License 2.0
 description: Highly optimized Google Gemini pipeline with advanced image generation capabilities, intelligent compression, and streamlined processing workflows.


### PR DESCRIPTION
Refactor file reading logic to use Storage provider and pathlib for file path handling.

Currently, using S3 as file storage prevents files from being retrieved. For example, when generating images using the Gemini 3 Image Pro model, no image context information will be available.

Therefore, I modified the code to follow the same logic as the `/v1/files/{file-id}/content` API:

https://github.com/open-webui/open-webui/blob/main/backend/open_webui/routers/files.py#L559