### PR TITLE
fix: update version numbers and improve logging level handling

### DIFF
--- a/filters/time_token_tracker.py
+++ b/filters/time_token_tracker.py
@@ -4,7 +4,7 @@ author: owndev
 author_url: https://github.com/owndev/
 project_url: https://github.com/owndev/Open-WebUI-Functions
 funding_url: https://github.com/sponsors/owndev
-version: 2.5.1
+version: 2.5.2
 license: Apache License 2.0
 description: A filter for tracking the response time and token usage of a request with Azure Log Analytics integration.
 features:
@@ -213,7 +213,7 @@ class Filter:
             return False
 
         log = logging.getLogger("time_token_tracker._send_to_log_analytics_async")
-        log.setLevel(SRC_LOG_LEVELS["OPENAI"])
+        log.setLevel(SRC_LOG_LEVELS.get("OPENAI", logging.INFO))
 
         method = "POST"
         content_type = "application/json"
@@ -364,7 +364,7 @@ class Filter:
         self, body: dict, __user__: Optional[dict] = None, __event_emitter__=None
     ) -> dict:
         log = logging.getLogger("time_token_tracker.outlet")
-        log.setLevel(SRC_LOG_LEVELS["OPENAI"])
+        log.setLevel(SRC_LOG_LEVELS.get("OPENAI", logging.INFO))
 
         global start_time, request_token_count, response_token_count
         end_time = time.time()

--- a/pipelines/azure/azure_ai_foundry.py
+++ b/pipelines/azure/azure_ai_foundry.py
@@ -4,7 +4,7 @@ author: owndev
 author_url: https://github.com/owndev/
 project_url: https://github.com/owndev/Open-WebUI-Functions
 funding_url: https://github.com/sponsors/owndev
-version: 2.6.0
+version: 2.6.1
 license: Apache License 2.0
 description: A pipeline for interacting with Azure AI services, enabling seamless communication with various AI models via configurable headers and robust error handling. This includes support for Azure OpenAI models as well as other Azure AI models by dynamically managing headers and request configurations. Azure AI Search (RAG) integration is only supported with Azure OpenAI endpoints.
 features:
@@ -1554,7 +1554,7 @@ class Pipe:
             Response from Azure AI API, which could be a string, dictionary or streaming response
         """
         log = logging.getLogger("azure_ai.pipe")
-        log.setLevel(SRC_LOG_LEVELS["OPENAI"])
+        log.setLevel(SRC_LOG_LEVELS.get("OPENAI", logging.INFO))
 
         # Validate the request body
         self.validate_body(body)


### PR DESCRIPTION
This pull request makes minor updates to improve logging robustness and updates version numbers for both the `time_token_tracker` filter and the `azure_ai_foundry` pipeline. The main change is ensuring that logging falls back to a default level if the expected log level is missing from `SRC_LOG_LEVELS`.

Logging improvements:

* Updated logging setup in `time_token_tracker.py` and `azure_ai_foundry.py` to use `SRC_LOG_LEVELS.get("OPENAI", logging.INFO)` instead of direct dictionary access, preventing potential `KeyError` if the log level is not present. [[1]](diffhunk://#diff-22d04c55e964a644afc44cf9073ef9055baa3d0276a02c6aa432778af167d999L216-R216) [[2]](diffhunk://#diff-22d04c55e964a644afc44cf9073ef9055baa3d0276a02c6aa432778af167d999L367-R367) [[3]](diffhunk://#diff-05e93e0ba107cc4bac8dbe7e8c862bec3c82a2963dc6b4d67801bd44c61083e5L1557-R1557)

Version updates:

* Bumped version in `filters/time_token_tracker.py` from 2.5.1 to 2.5.2.
* Bumped version in `pipelines/azure/azure_ai_foundry.py` from 2.6.0 to 2.6.1.