### PR TITLE
fix(google_gemini): fix non-streaming response persistence and add usage tracking

### DIFF
--- a/pipelines/google/google_gemini.py
+++ b/pipelines/google/google_gemini.py
@@ -3606,14 +3606,15 @@ class Pipe:
                     content = (
                         full_response if full_response else "[No content generated]"
                     )
-                    result = {
-                        "choices": [
-                            {"message": {"role": "assistant", "content": content}}
-                        ],
-                    }
+
+                    # Emit usage data so Open WebUI can capture it before we return the string
                     if usage:
-                        result["usage"] = usage
-                    return result
+                        await __event_emitter__({"type": "usage", "data": usage})
+
+                    # Return the content as a string for non-streaming calls.
+                    # This ensures Open WebUI captures the final content correctly
+                    # and propagates it to subsequent events (like outlet filters).
+                    return content
 
                 except Exception as e:
                     self.log.exception(


### PR DESCRIPTION
This PR fixes the issue where model responses would disappear from the browser chat window when streaming was disabled.

### Problem:
In non-streaming mode, returning a dictionary (OpenAI-compatible format) was leading to empty `content` fields in subsequent background events (like `chat:outlet` or follow-up question generation). When these events reached the browser, they would overwrite the previously displayed response with an empty string, causing it to vanish.

### Solution:
1. **Return a String**: Switched the return type of the `pipe` method to a simple string for non-streaming calls. Open WebUI recognizes this as a finalized message and definitively sets the message content, preventing background tasks from overwriting it.
2. **Usage Tracking**: Since we are now returning a string, we manually emit the `usage` data via the `__event_emitter__` right before the return. This ensures token counts are still captured and saved to the database.
3. **Avoid Duplication**: Removed manual `chat:message` event emission in the non-streaming path as the string return already handles UI display correctly.